### PR TITLE
feat(geocode query): add exactMatch option

### DIFF
--- a/src/command/geocode.command.ts
+++ b/src/command/geocode.command.ts
@@ -1,5 +1,6 @@
+import { ExactMatchNotFoundException } from '../exception';
 import { GeocodeQueryInterface } from '../interface';
-import { GeocodeQuery } from '../model';
+import { GeocodeQuery, Location } from '../model';
 import { AbstractLocationCommand } from './abstract-location.command';
 
 export class GeocodeCommand<ProviderRequestType = any, ProviderResponseType = any> extends AbstractLocationCommand<
@@ -9,5 +10,32 @@ export class GeocodeCommand<ProviderRequestType = any, ProviderResponseType = an
 > {
     static queryClass(): typeof GeocodeQuery {
         return GeocodeQuery;
+    }
+
+    async execute(query: GeocodeQueryInterface): Promise<Location[]> {
+        const locations: Location[] = await super.execute(query);
+
+        this.validateExactMatchOption(query, locations);
+
+        return locations;
+    }
+
+    /**
+     * @throws {ExactMatchNotFoundException}
+     */
+    private validateExactMatchOption(query: GeocodeQueryInterface, locations: Location[]): void {
+        if (!query.exactMatch) {
+            return;
+        }
+
+        if (locations.length > 1) {
+            throw new ExactMatchNotFoundException('More than one result', { query, locations });
+        }
+
+        const location: Location = locations[0];
+
+        if ((query.countryCode && query.countryCode !== location.countryCode) || (query.stateCode && query.stateCode !== location.stateCode)) {
+            throw new ExactMatchNotFoundException('Does not match the terms of the query', { query, location });
+        }
     }
 }

--- a/src/exception/exact-match-not-found.exception.ts
+++ b/src/exception/exact-match-not-found.exception.ts
@@ -1,0 +1,3 @@
+import { GeocoderException } from './geocoder.exception';
+
+export class ExactMatchNotFoundException extends GeocoderException {}

--- a/src/exception/index.ts
+++ b/src/exception/index.ts
@@ -1,4 +1,5 @@
 export * from './geocoder.exception';
+export * from './exact-match-not-found.exception';
 export * from './invalid-argument.exception';
 export * from './invalid-credentials.exception';
 export * from './invalid-server-response.exception';

--- a/src/geocoder/provider-aggregator.ts
+++ b/src/geocoder/provider-aggregator.ts
@@ -58,6 +58,7 @@ export class ProviderAggregator extends AbstractGeocoder {
     }
 
     registerProvider(provider: AbstractProvider): this {
+        provider.setLogger(this.getLogger());
         this.providers.push(provider);
 
         return this;

--- a/src/interface/geocode-query.interface.ts
+++ b/src/interface/geocode-query.interface.ts
@@ -7,6 +7,22 @@ export interface GeocodeQueryInterface extends QueryInterface {
     address: string;
 
     /**
+     * This query option is suitable for those who have an exact formatted address and needs to get the geo-data of this address.
+     * Currently this option only works if accuracy is not specified or it is set to AccuracyEnum.HOUSE_NUMBER
+     * and if query limit is not specified or it is more then one, otherwise ValidationException will be thrown.
+     *
+     * If a provider returns more than one possible option, then ExactMatchNotFoundException will be thrown.
+     *
+     * If the provider returns only one result and the optional countryCode and stateCode options are passed in the query,
+     * the result will be checked to match with this query options and if they do not match, then ExactMatchNotFoundException will be thrown.
+     *
+     * If successful, an array with one element will be returned.
+     *
+     * @default false
+     */
+    exactMatch?: boolean;
+
+    /**
      * @default not applicable
      */
     country?: string;

--- a/src/model/geocode-query.ts
+++ b/src/model/geocode-query.ts
@@ -1,6 +1,7 @@
-import { Type } from 'class-transformer';
-import { IsNotEmpty, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { IsBoolean, IsNotEmpty, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
 import { GeocodeQueryInterface } from '../interface';
+import { IsExactMatchApplicable } from '../validation';
 import { Query } from './query';
 
 export class GeocodeQuery extends Query implements GeocodeQueryInterface {
@@ -10,6 +11,12 @@ export class GeocodeQuery extends Query implements GeocodeQueryInterface {
     @MaxLength(100)
     @Type(() => String)
     address: string;
+
+    @IsExactMatchApplicable()
+    @IsBoolean()
+    @Transform((v: boolean) => !!v, { toClassOnly: true })
+    @Type(() => Boolean)
+    exactMatch: boolean = false;
 
     @IsOptional()
     @IsString()

--- a/src/provider/chain.provider.ts
+++ b/src/provider/chain.provider.ts
@@ -1,4 +1,4 @@
-import { InvalidArgumentException } from '../exception';
+import { InvalidArgumentException, ValidationException } from '../exception';
 import { GeocodeQueryInterface, ReverseQueryInterface, SuggestQueryInterface } from '../interface';
 import { LoggerInterface } from '../logger';
 import { AbstractHttpProvider, AbstractProvider, Location, Suggestion } from '../model';
@@ -21,7 +21,11 @@ export class ChainProvider extends AbstractProvider {
                     return locations;
                 }
             } catch (err) {
-                this.getLogger().error(err);
+                if (err instanceof ValidationException) {
+                    throw err;
+                }
+
+                this.getLogger().warn(err);
             }
         }
 
@@ -37,7 +41,11 @@ export class ChainProvider extends AbstractProvider {
                     return locations;
                 }
             } catch (err) {
-                this.getLogger().error(err);
+                if (err instanceof ValidationException) {
+                    throw err;
+                }
+
+                this.getLogger().warn(err);
             }
         }
 
@@ -49,7 +57,11 @@ export class ChainProvider extends AbstractProvider {
             try {
                 return await provider.suggest(query);
             } catch (err) {
-                this.getLogger().error(err);
+                if (err instanceof ValidationException) {
+                    throw err;
+                }
+
+                this.getLogger().warn(err);
             }
         }
 

--- a/src/provider/stateful-chain.provider.ts
+++ b/src/provider/stateful-chain.provider.ts
@@ -1,4 +1,4 @@
-import { InvalidArgumentException } from '../exception';
+import { InvalidArgumentException, ValidationException } from '../exception';
 import { GeocodeQueryInterface, ReverseQueryInterface, SuggestQueryInterface } from '../interface';
 import { LoggerInterface } from '../logger';
 import { AbstractHttpProvider, AbstractProvider, Location, Suggestion } from '../model';
@@ -30,7 +30,11 @@ export class StatefulChainProvider extends AbstractProvider {
                     return locations;
                 }
             } catch (err) {
-                this.getLogger().error(err);
+                if (err instanceof ValidationException) {
+                    throw err;
+                }
+
+                this.getLogger().warn(err);
             }
         }
 
@@ -48,7 +52,11 @@ export class StatefulChainProvider extends AbstractProvider {
                     return locations;
                 }
             } catch (err) {
-                this.getLogger().error(err);
+                if (err instanceof ValidationException) {
+                    throw err;
+                }
+
+                this.getLogger().warn(err);
             }
         }
 
@@ -62,7 +70,11 @@ export class StatefulChainProvider extends AbstractProvider {
 
                 return await provider.suggest(query);
             } catch (err) {
-                this.getLogger().error(err);
+                if (err instanceof ValidationException) {
+                    throw err;
+                }
+
+                this.getLogger().warn(err);
             }
         }
 

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -1,0 +1,2 @@
+export * from './is-exact-match-applicable.constraint';
+export * from './is-exact-match-applicable';

--- a/src/validation/is-exact-match-applicable.constraint.ts
+++ b/src/validation/is-exact-match-applicable.constraint.ts
@@ -1,0 +1,33 @@
+import { ValidationArguments, ValidatorConstraint, ValidatorConstraintInterface } from 'class-validator';
+import { AccuracyEnum } from '../model';
+
+@ValidatorConstraint({ name: 'isExactMatchApplicable' })
+export class IsExactMatchApplicableConstraint implements ValidatorConstraintInterface {
+    validate(exactMatch: boolean, args: ValidationArguments): boolean {
+        const [accuracyProperty, limitProperty]: any = args.constraints;
+        const accuracy: AccuracyEnum = (args.object as any)[accuracyProperty];
+        const limit: number = (args.object as any)[limitProperty];
+
+        if (!exactMatch) {
+            return true;
+        }
+
+        if (!accuracy && 'undefined' === typeof limit) {
+            return true;
+        }
+
+        if (accuracy && AccuracyEnum.HOUSE_NUMBER !== accuracy) {
+            return false;
+        }
+
+        if (limit && 1 === limit) {
+            return false;
+        }
+
+        return true;
+    }
+
+    defaultMessage(_args: ValidationArguments): string {
+        return 'Can be used only if accuracy is not specified or it is set to AccuracyEnum.HOUSE_NUMBER and if limit is not specified or it is more than 1';
+    }
+}

--- a/src/validation/is-exact-match-applicable.ts
+++ b/src/validation/is-exact-match-applicable.ts
@@ -1,0 +1,14 @@
+import { registerDecorator, ValidationOptions } from 'class-validator';
+import { IsExactMatchApplicableConstraint } from './is-exact-match-applicable.constraint';
+
+export function IsExactMatchApplicable(options?: ValidationOptions): any {
+    return (object: object, propertyName: string): void => {
+        registerDecorator({
+            target: object.constructor,
+            propertyName,
+            options,
+            constraints: ['accuracy', 'limit'],
+            validator: IsExactMatchApplicableConstraint,
+        });
+    };
+}

--- a/test/e2e/common/shared.ts
+++ b/test/e2e/common/shared.ts
@@ -1,5 +1,11 @@
 import MockAdapter from 'axios-mock-adapter';
-import { InvalidCredentialsException, InvalidServerResponseException, QuotaExceededException, UnsupportedAccuracyException } from '../../../src/exception';
+import {
+    ExactMatchNotFoundException,
+    InvalidCredentialsException,
+    InvalidServerResponseException,
+    QuotaExceededException,
+    UnsupportedAccuracyException,
+} from '../../../src/exception';
 import { QueryInterface } from '../../../src/interface';
 import { AbstractProvider, AccuracyEnum } from '../../../src/model';
 import { getAvailableAccuracies } from '../../../src/util';
@@ -77,6 +83,46 @@ export function sharedCommandHttpStatusBehaviours(mock: MockAdapter, provider: A
             mock.onGet(provider[url]).reply(0);
 
             return provider[method](query).should.be.rejectedWith(InvalidServerResponseException);
+        });
+    });
+}
+
+export function sharedGeocodeCommandBehaviours(
+    mock: MockAdapter,
+    provider: AbstractProvider,
+    url: string,
+    rawResponse: any,
+): void {
+    describe('#sharedGeocodeCommandBehaviours', () => {
+        describe('#exactMatch', () => {
+            it('should throw ExactMatchNotFoundException with "More than one result" message', async () => {
+                mock.onGet(url).reply(200, rawResponse);
+
+                return provider.geocode({
+                    exactMatch: true,
+                    address: 'test123',
+                }).should.be.rejectedWith(ExactMatchNotFoundException, 'More than one result');
+            });
+
+            it('should throw ExactMatchNotFoundException with "Does not match the terms of the query" message', async () => {
+                mock.onGet(url).reply(200, rawResponse);
+
+                return provider.geocode({
+                    exactMatch: true,
+                    address: 'test123',
+                    countryCode: 'AA',
+                }).should.be.rejectedWith(ExactMatchNotFoundException, 'Does not match the terms of the query');
+            });
+
+            it('should throw ExactMatchNotFoundException with "Does not match the terms of the query" message', async () => {
+                mock.onGet(url).reply(200, rawResponse);
+
+                return provider.geocode({
+                    exactMatch: true,
+                    address: 'test123',
+                    stateCode: 'AA',
+                }).should.be.rejectedWith(ExactMatchNotFoundException, 'Does not match the terms of the query');
+            });
         });
     });
 }

--- a/test/e2e/provider/chain.provider.spec.ts
+++ b/test/e2e/provider/chain.provider.spec.ts
@@ -60,6 +60,13 @@ describe('ChainProvider (2e2)', () => {
 
             return provider.geocode(geocodeQuery).should.become(providerParsedGeocodeResponse);
         });
+
+        it('should return empty array', async () => {
+            mock.onGet(ArcgisGeocodeCommand.getUrl()).reply(200, []);
+            mock.onGet(GoogleMapsGeocodeCommand.getUrl()).reply(200, []);
+
+            return provider.geocode(geocodeQuery).should.become([]);
+        });
     });
 
     describe('#reverse', () => {
@@ -79,6 +86,13 @@ describe('ChainProvider (2e2)', () => {
 
             return provider.reverse(reverseQuery).should.become(providerParsedReverseResponse);
         });
+
+        it('should return empty array', async () => {
+            mock.onGet(ArcgisReverseCommand.getUrl()).reply(200, []);
+            mock.onGet(GoogleMapsReverseCommand.getUrl()).reply(200, []);
+
+            return provider.reverse(reverseQuery).should.become([]);
+        });
     });
 
     describe('#suggest', () => {
@@ -97,6 +111,13 @@ describe('ChainProvider (2e2)', () => {
             mock.onGet(GoogleMapsSuggestCommand.getUrl()).reply(200, providerRawSuggestResponse);
 
             return provider.suggest(suggestQuery).should.become(providerParsedSuggestResponse);
+        });
+
+        it('should return empty array', async () => {
+            mock.onGet(ArcgisSuggestCommand.getUrl()).reply(500);
+            mock.onGet(GoogleMapsSuggestCommand.getUrl()).reply(500);
+
+            return provider.suggest(suggestQuery).should.become([]);
         });
     });
 });

--- a/test/e2e/provider/here.provider.spec.ts
+++ b/test/e2e/provider/here.provider.spec.ts
@@ -4,7 +4,12 @@ import { LocationInterface, QueryInterface } from '../../../src/interface';
 import { AccuracyEnum } from '../../../src/model';
 import { HereGeocodeCommand, HereProvider, HereReverseCommand } from '../../../src/provider';
 import { geocodeQueryFixture, reverseQueryFixture } from '../../fixture/model/query.fixture';
-import { providerParsedResponse, providerRawResponse } from '../../fixture/provider/here.fixture';
+import {
+    providerParsedGeocodeResponse,
+    providerParsedReverseResponse,
+    providerRawGeocodeResponse,
+    providerRawReverseResponse,
+} from '../../fixture/provider/here.fixture';
 import { sharedAccuracyBehaviours, sharedCommandBehaviours } from '../common/shared';
 
 describe('HereProvider (2e2)', () => {
@@ -39,12 +44,12 @@ describe('HereProvider (2e2)', () => {
     describe('#geocode', () => {
         const url: string = HereGeocodeCommand.getUrl();
 
-        sharedBehaviours(url, 'geocode', geocodeQueryFixture, providerRawResponse, providerParsedResponse);
+        sharedBehaviours(url, 'geocode', geocodeQueryFixture, providerRawGeocodeResponse, providerParsedGeocodeResponse);
     });
 
     describe('#reverse', () => {
         const url: string = HereReverseCommand.getUrl();
 
-        sharedBehaviours(url, 'reverse', reverseQueryFixture, providerRawResponse, providerParsedResponse);
+        sharedBehaviours(url, 'reverse', reverseQueryFixture, providerRawReverseResponse, providerParsedReverseResponse);
     });
 });

--- a/test/e2e/provider/stateful-chain.provider.spec.ts
+++ b/test/e2e/provider/stateful-chain.provider.spec.ts
@@ -60,6 +60,13 @@ describe('StatefulChainProvider (2e2)', () => {
 
             return provider.geocode(geocodeQuery).should.become(providerParsedGeocodeResponse);
         });
+
+        it('should return empty array', async () => {
+            mock.onGet(ArcgisGeocodeCommand.getUrl()).reply(200, []);
+            mock.onGet(GoogleMapsGeocodeCommand.getUrl()).reply(200, []);
+
+            return provider.geocode(geocodeQuery).should.become([]);
+        });
     });
 
     describe('#reverse', () => {
@@ -79,6 +86,13 @@ describe('StatefulChainProvider (2e2)', () => {
 
             return provider.reverse(reverseQuery).should.become(providerParsedReverseResponse);
         });
+
+        it('should return empty array', async () => {
+            mock.onGet(ArcgisReverseCommand.getUrl()).reply(200, []);
+            mock.onGet(GoogleMapsReverseCommand.getUrl()).reply(200, []);
+
+            return provider.reverse(reverseQuery).should.become([]);
+        });
     });
 
     describe('#suggest', () => {
@@ -97,6 +111,13 @@ describe('StatefulChainProvider (2e2)', () => {
             mock.onGet(GoogleMapsSuggestCommand.getUrl()).reply(200, providerRawSuggestResponse);
 
             return provider.suggest(suggestQuery).should.become(providerParsedSuggestResponse);
+        });
+
+        it('should return empty array', async () => {
+            mock.onGet(ArcgisSuggestCommand.getUrl()).reply(500);
+            mock.onGet(GoogleMapsSuggestCommand.getUrl()).reply(500);
+
+            return provider.suggest(suggestQuery).should.become([]);
         });
     });
 });

--- a/test/fixture/provider/here.fixture.ts
+++ b/test/fixture/provider/here.fixture.ts
@@ -1,6 +1,6 @@
 import { LocationInterface } from '../../../src/interface';
 
-export const providerRawResponse: Readonly<any> = Object.freeze({
+const providerRawLocationResponse: Readonly<any> = Object.freeze({
     Response: {
         MetaInfo: { Timestamp: '2019-02-19T23:39:16.057+0000' },
         View: [
@@ -48,7 +48,7 @@ export const providerRawResponse: Readonly<any> = Object.freeze({
     },
 });
 
-export const providerParsedResponse: ReadonlyArray<LocationInterface> = Object.freeze<LocationInterface>([
+const providerParsedLocationResponse: ReadonlyArray<LocationInterface> = Object.freeze<LocationInterface>([
     {
         latitude: 41.7332379,
         longitude: -87.5959685,
@@ -62,6 +62,12 @@ export const providerParsedResponse: ReadonlyArray<LocationInterface> = Object.f
         postalCode: '60619',
         provider: 'HereProvider',
         formattedAddress: '1158 E 89th St, Chicago, IL 60619, United States',
-        raw: providerRawResponse.Response.View[0].Result[0],
+        raw: providerRawLocationResponse.Response.View[0].Result[0],
     },
 ]);
+
+export const providerRawGeocodeResponse: Readonly<any> = providerRawLocationResponse;
+export const providerParsedGeocodeResponse: ReadonlyArray<LocationInterface> = providerParsedLocationResponse;
+
+export const providerRawReverseResponse: Readonly<any> = providerRawLocationResponse;
+export const providerParsedReverseResponse: ReadonlyArray<LocationInterface> = providerParsedLocationResponse;

--- a/test/integration/provider/chain.provider.spec.ts
+++ b/test/integration/provider/chain.provider.spec.ts
@@ -1,0 +1,83 @@
+import Axios, { AxiosInstance } from 'axios';
+import { Geocoder } from '../../../src/geocoder';
+import { GeocodeQueryInterface, ReverseQueryInterface, SuggestQueryInterface } from '../../../src/interface';
+import { AccuracyEnum } from '../../../src/model';
+import { ArcgisProvider, ChainProvider } from '../../../src/provider';
+import { geocodeQueryFixture, reverseQueryFixture, suggestQueryFixture } from '../../fixture/model/query.fixture';
+
+describe('ChainProvider (integration)', () => {
+    let client: AxiosInstance;
+    let geocoder: Geocoder;
+    let geocodeQuery: GeocodeQueryInterface;
+    let reverseQuery: ReverseQueryInterface;
+    let suggestQuery: SuggestQueryInterface;
+
+    beforeEach(() => {
+        geocodeQuery = { ...geocodeQueryFixture };
+        reverseQuery = { ...reverseQueryFixture };
+        suggestQuery = { ...suggestQueryFixture };
+
+        client = Axios.create();
+
+        const provider: ChainProvider = new ChainProvider([new ArcgisProvider(client)]);
+
+        geocoder = new Geocoder(provider);
+    });
+
+    describe('#geocode', () => {
+        it('should return response', async () => {
+            return geocoder
+                .geocode(geocodeQuery)
+                .should.eventually.be.an('array')
+                .with.length(1);
+        });
+
+        it('should return empty array', async () => {
+            return geocoder
+                .geocode({
+                    address: '123123123',
+                    exactMatch: true,
+                })
+                .should.eventually.be.an('array')
+                .with.length(0);
+        });
+    });
+
+    describe('#reverse', () => {
+        it('should return expected response', async () => {
+            return geocoder
+                .reverse(reverseQuery)
+                .should.eventually.be.an('array')
+                .with.length(1);
+        });
+
+        it('should return empty array', async () => {
+            return geocoder
+                .reverse({
+                    accuracy: AccuracyEnum.HOUSE_NUMBER,
+                    lat: 0,
+                    lon: 0,
+                })
+                .should.eventually.be.an('array')
+                .with.length(0);
+        });
+    });
+
+    describe('#suggest', () => {
+        it('should return expected response', async () => {
+            return geocoder
+                .suggest(suggestQuery)
+                .should.eventually.be.an('array')
+                .with.length(3);
+        });
+
+        it('should return empty array', async () => {
+            return geocoder
+                .suggest({
+                    address: '123123123',
+                })
+                .should.eventually.be.an('array')
+                .with.length(0);
+        });
+    });
+});

--- a/test/integration/provider/stateful-chain.provider.spec.ts
+++ b/test/integration/provider/stateful-chain.provider.spec.ts
@@ -1,0 +1,83 @@
+import Axios, { AxiosInstance } from 'axios';
+import { Geocoder } from '../../../src/geocoder';
+import { GeocodeQueryInterface, ReverseQueryInterface, SuggestQueryInterface } from '../../../src/interface';
+import { AccuracyEnum } from '../../../src/model';
+import { ArcgisProvider, StatefulChainProvider } from '../../../src/provider';
+import { geocodeQueryFixture, reverseQueryFixture, suggestQueryFixture } from '../../fixture/model/query.fixture';
+
+describe('StatefulChainProvider (integration)', () => {
+    let client: AxiosInstance;
+    let geocoder: Geocoder;
+    let geocodeQuery: GeocodeQueryInterface;
+    let reverseQuery: ReverseQueryInterface;
+    let suggestQuery: SuggestQueryInterface;
+
+    beforeEach(() => {
+        geocodeQuery = { ...geocodeQueryFixture };
+        reverseQuery = { ...reverseQueryFixture };
+        suggestQuery = { ...suggestQueryFixture };
+
+        client = Axios.create();
+
+        const provider: StatefulChainProvider = new StatefulChainProvider([new ArcgisProvider(client)]);
+
+        geocoder = new Geocoder(provider);
+    });
+
+    describe('#geocode', () => {
+        it('should return response', async () => {
+            return geocoder
+                .geocode(geocodeQuery)
+                .should.eventually.be.an('array')
+                .with.length(1);
+        });
+
+        it('should return empty array', async () => {
+            return geocoder
+                .geocode({
+                    address: '123123123',
+                    exactMatch: true,
+                })
+                .should.eventually.be.an('array')
+                .with.length(0);
+        });
+    });
+
+    describe('#reverse', () => {
+        it('should return expected response', async () => {
+            return geocoder
+                .reverse(reverseQuery)
+                .should.eventually.be.an('array')
+                .with.length(1);
+        });
+
+        it('should return empty array', async () => {
+            return geocoder
+                .reverse({
+                    accuracy: AccuracyEnum.HOUSE_NUMBER,
+                    lat: 0,
+                    lon: 0,
+                })
+                .should.eventually.be.an('array')
+                .with.length(0);
+        });
+    });
+
+    describe('#suggest', () => {
+        it('should return expected response', async () => {
+            return geocoder
+                .suggest(suggestQuery)
+                .should.eventually.be.an('array')
+                .with.length(3);
+        });
+
+        it('should return empty array', async () => {
+            return geocoder
+                .suggest({
+                    address: '123123123',
+                })
+                .should.eventually.be.an('array')
+                .with.length(0);
+        });
+    });
+});

--- a/test/unit/geocoder/provider-aggregator.spec.ts
+++ b/test/unit/geocoder/provider-aggregator.spec.ts
@@ -46,7 +46,7 @@ describe('ProviderAggregator (unit)', () => {
         });
 
         it('should throw ProviderNotRegisteredException if provider not registered', async () => {
-            return geocoder.geocode(geocodeQueryFixture).should.rejectedWith(ProviderNotRegisteredException, 'No provider registered.');
+            return geocoder.geocode(geocodeQueryFixture).should.be.rejectedWith(ProviderNotRegisteredException, 'No provider registered.');
         });
     });
 
@@ -56,7 +56,7 @@ describe('ProviderAggregator (unit)', () => {
         });
 
         it('should throw ProviderNotRegisteredException if provider not registered', async () => {
-            return geocoder.reverse(reverseQueryFixture).should.rejectedWith(ProviderNotRegisteredException, 'No provider registered.');
+            return geocoder.reverse(reverseQueryFixture).should.be.rejectedWith(ProviderNotRegisteredException, 'No provider registered.');
         });
     });
 

--- a/test/unit/model/geocode-query.spec.ts
+++ b/test/unit/model/geocode-query.spec.ts
@@ -1,0 +1,54 @@
+import { plainToClass } from 'class-transformer';
+import { ValidationError, Validator } from 'class-validator';
+import { AccuracyEnum, GeocodeQuery } from '../../../src/model';
+
+describe('GeocodeQuery (unit)', () => {
+    describe('#validation', () => {
+        const validator: Validator = new Validator();
+
+        it('should throw error with IsExactMatchApplicable with AccuracyEnum.STREET_NAME and limit 1', async () => {
+            const query: GeocodeQuery = plainToClass(GeocodeQuery, {
+                exactMatch: true,
+                accuracy: AccuracyEnum.STREET_NAME,
+                address: 'test123',
+                limit: 1,
+            });
+
+            const errors: ValidationError[] = await validator.validate(query);
+
+            errors.length.should.be.equal(1);
+            errors[0].constraints.should.be.eql({
+                isExactMatchApplicable:
+                    'Can be used only if accuracy is not specified or it is set to AccuracyEnum.HOUSE_NUMBER and if limit is not specified or it is more than 1',
+            });
+        });
+
+        it('should throw error with IsExactMatchApplicable with limit 1', async () => {
+            const query: GeocodeQuery = plainToClass(GeocodeQuery, {
+                exactMatch: true,
+                accuracy: AccuracyEnum.HOUSE_NUMBER,
+                address: 'test123',
+                limit: 1,
+            });
+
+            const errors: ValidationError[] = await validator.validate(query);
+
+            errors.length.should.be.equal(1);
+            errors[0].constraints.should.be.eql({
+                isExactMatchApplicable:
+                    'Can be used only if accuracy is not specified or it is set to AccuracyEnum.HOUSE_NUMBER and if limit is not specified or it is more than 1',
+            });
+        });
+
+        it('should be ok', async () => {
+            const query: GeocodeQuery = plainToClass(GeocodeQuery, {
+                exactMatch: true,
+                address: 'test123',
+            });
+
+            const errors: ValidationError[] = await validator.validate(query);
+
+            return errors.should.be.deep.eq([]);
+        });
+    });
+});

--- a/test/unit/provider/chain.provider.spec.ts
+++ b/test/unit/provider/chain.provider.spec.ts
@@ -1,9 +1,7 @@
 import Axios, { AxiosInstance } from 'axios';
-import { plainToClass } from 'class-transformer';
-import { InvalidArgumentException } from '../../../src/exception';
+import { InvalidArgumentException, ValidationException } from '../../../src/exception';
 import { NullLogger } from '../../../src/logger';
-import { GeocodeQuery, ReverseQuery } from '../../../src/model';
-import { ChainProvider, GoogleMapsProvider, HereProvider, MapQuestProvider } from '../../../src/provider';
+import { ArcgisProvider, ChainProvider, GoogleMapsProvider, MapQuestProvider } from '../../../src/provider';
 
 describe('ChainProvider (unit)', () => {
     let client: AxiosInstance;
@@ -12,7 +10,7 @@ describe('ChainProvider (unit)', () => {
     beforeEach(() => {
         client = Axios.create();
 
-        provider = new ChainProvider([new HereProvider(client, 'test', 'test')]);
+        provider = new ChainProvider([new ArcgisProvider(client)]);
     });
 
     describe('#constructor', () => {
@@ -30,14 +28,12 @@ describe('ChainProvider (unit)', () => {
             return provider.geocode.should.be.instanceOf(Function);
         });
 
-        it('should return empty result array', async () => {
+        it('should throw ValidationException on short address', async () => {
             return provider
-                .geocode(
-                    plainToClass(GeocodeQuery, {
-                        address: 'test',
-                    }),
-                )
-                .should.become([]);
+                .geocode({
+                    address: 'test',
+                })
+                .should.be.rejectedWith(ValidationException);
         });
     });
 
@@ -46,15 +42,36 @@ describe('ChainProvider (unit)', () => {
             return provider.reverse.should.be.instanceOf(Function);
         });
 
-        it('should return empty result array', async () => {
+        it('should throw ValidationException on invalid lat option', async () => {
             return provider
-                .reverse(
-                    plainToClass(ReverseQuery, {
-                        lat: 123,
-                        lon: 123,
-                    }),
-                )
-                .should.become([]);
+                .reverse({
+                    lat: 123,
+                    lon: 123,
+                })
+                .should.be.rejectedWith(ValidationException);
+        });
+
+        it('should throw ValidationException on invalid lon option', async () => {
+            return provider
+                .reverse({
+                    lat: 90,
+                    lon: 200,
+                })
+                .should.be.rejectedWith(ValidationException);
+        });
+    });
+
+    describe('#suggest', () => {
+        it('should be instance of Function', async () => {
+            return provider.suggest.should.be.instanceOf(Function);
+        });
+
+        it('should throw ValidationException on short address', async () => {
+            return provider
+                .suggest({
+                    address: 'test',
+                })
+                .should.be.rejectedWith(ValidationException);
         });
     });
 


### PR DESCRIPTION
This is a 🙋 feature or enhancement.

## Summary

This query option is suitable for those who have an exact formatted address and needs to get the geo-data of this address.

Currently this option only works if accuracy is not specified or it is set to AccuracyEnum.HOUSE_NUMBER and if query limit is not specified or it is more then one, otherwise ValidationException will be thrown.

If a provider returns more than one possible option, then ExactMatchNotFoundException will be thrown.

If the provider returns only one result and the optional countryCode and stateCode options are passed in the query, the result will be checked to match with this query options and if they do not match, then ExactMatchNotFoundException will be thrown.

If successful, an array with one element will be returned.