### PR TITLE
fix(provider place-details): restrict google place details query fields

### DIFF
--- a/src/provider/google-maps/command/google-maps-place-details.command.ts
+++ b/src/provider/google-maps/command/google-maps-place-details.command.ts
@@ -24,6 +24,11 @@ export class GoogleMapsPlaceDetailsCommand extends GoogleMapsLocationCommandMixi
             placeid: query.placeId,
             language: query.language,
             sensor: false,
+            /**
+             * @see interface
+             * used basic fields
+             */
+            fields: 'address_component,formatted_address,geometry,place_id,type',
         };
 
         if (query.countryCode) {

--- a/src/provider/google-maps/interface/google-maps-place-details-query.interface.ts
+++ b/src/provider/google-maps/interface/google-maps-place-details-query.interface.ts
@@ -2,4 +2,13 @@ import { GoogleMapsQueryInterface } from './google-maps-query.interface';
 
 export interface GoogleMapsPlaceDetailsQueryInterface extends GoogleMapsQueryInterface {
     placeid: string;
+    /**
+     * Warning: If you do not specify at least one field with a request,
+     * or if you omit the fields parameter from a request, ALL possible fields will be returned,
+     * and you will be billed accordingly. This applies only to Place Details requests.
+     *
+     * @link https://developers.google.com/places/web-service/details
+     * @link https://developers.google.com/maps/documentation/javascript/reference/places-service#PlaceResult
+     */
+    fields?: string;
 }

--- a/test/fixture/provider/google.fixture.ts
+++ b/test/fixture/provider/google.fixture.ts
@@ -218,8 +218,8 @@ export const providerRawPlaceDetailsResponse: Readonly<any> = Object.freeze({
                 types: ['postal_code_suffix'],
             },
         ],
-        adr_address:
-            '<span class="street-address">1158 E 89th St</span>, <span class="locality">Chicago</span>, <span class="region">IL</span> <span class="postal-code">60619-7017</span>, <span class="country-name">USA</span>',
+        // adr_address:
+        //     '<span class="street-address">1158 E 89th St</span>, <span class="locality">Chicago</span>, <span class="region">IL</span> <span class="postal-code">60619-7017</span>, <span class="country-name">USA</span>',
         formatted_address: '1158 E 89th St, Chicago, IL 60619, USA',
         geometry: {
             location: {
@@ -237,18 +237,18 @@ export const providerRawPlaceDetailsResponse: Readonly<any> = Object.freeze({
                 },
             },
         },
-        icon: 'https://maps.gstatic.com/mapfiles/place_api/icons/geocode-71.png',
+        // icon: 'https://maps.gstatic.com/mapfiles/place_api/icons/geocode-71.png',
         // sometimes this field is not returned
         // id: 'bbbfd42eed9385648e42f6f331d54eac2d61cbca',
-        name: '1158 E 89th St',
+        // name: '1158 E 89th St',
         place_id: 'EiYxMTU4IEUgODl0aCBTdCwgQ2hpY2FnbywgSUwgNjA2MTksIFVTQSIxEi8KFAoSCZ9KkOIgJg6IEYkN8yihjBnAEIYJKhQKEgkJAlVQKiYOiBHg0_ra6hq5MA',
-        reference: 'EiYxMTU4IEUgODl0aCBTdCwgQ2hpY2FnbywgSUwgNjA2MTksIFVTQSIxEi8KFAoSCZ9KkOIgJg6IEYkN8yihjBnAEIYJKhQKEgkJAlVQKiYOiBHg0_ra6hq5MA',
+        // reference: 'EiYxMTU4IEUgODl0aCBTdCwgQ2hpY2FnbywgSUwgNjA2MTksIFVTQSIxEi8KFAoSCZ9KkOIgJg6IEYkN8yihjBnAEIYJKhQKEgkJAlVQKiYOiBHg0_ra6hq5MA',
         // sometimes this field is not returned
         // scope: 'GOOGLE',
         types: ['street_address'],
-        url: 'https://maps.google.com/?q=1158+E+89th+St,+Chicago,+IL+60619,+USA&ftid=0x880e2620e2904a9f:0x8850f56fdf8a5429',
-        utc_offset: -360,
-        vicinity: 'Chicago',
+        // url: 'https://maps.google.com/?q=1158+E+89th+St,+Chicago,+IL+60619,+USA&ftid=0x880e2620e2904a9f:0x8850f56fdf8a5429',
+        // utc_offset: -360,
+        // vicinity: 'Chicago',
     },
     status: 'OK',
 });


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://github.com/goparrot/geocoder/blob/master/CONTRIBUTING.md#contributing
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->

<!-- This is a 🙋 feature or enhancement. -->

<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `npm test` to verify this)
-->

## Summary
Restrict google place details query fields
<!--
  Provide a description of what your pull request changes.
-->

## Context
https://developers.google.com/places/web-service/details#fields
<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
