### PR TITLE
refactor(provider): adds signing to google maps provider requests geo…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@goparrot/geocoder",
     "description": "TypeScript GeoCoder, node geocoding library, supports google maps, mapquest, here, open street map, tom tom",
-    "version": "4.5.0",
+    "version": "4.5.1-dev.0",
     "author": "Coroliov Oleg",
     "license": "MIT",
     "private": false,

--- a/src/provider/google-maps/command/google-maps-geocode.command.ts
+++ b/src/provider/google-maps/command/google-maps-geocode.command.ts
@@ -3,17 +3,18 @@ import { GeocodeCommand } from '../../../command';
 import type { GeocodeQuery } from '../../../model';
 import type { GoogleMapsGeocodeQueryInterface } from '../interface';
 import { GoogleMapsLocationCommandMixin } from './mixin';
+import { urlSign } from '../../../util/url-signing';
 
 /**
  * @link {https://developers.google.com/maps/documentation/geocoding/intro#GeocodingRequests}
  */
 export class GoogleMapsGeocodeCommand extends GoogleMapsLocationCommandMixin(GeocodeCommand)<GoogleMapsGeocodeQueryInterface> {
-    constructor(httpClient: AxiosInstance, private readonly apiKey: string) {
-        super(httpClient, apiKey);
+    constructor(httpClient: AxiosInstance, private readonly apiKey: string, private readonly secret?: string) {
+        super(httpClient, apiKey, secret);
     }
 
     static getUrl(): string {
-        return 'https://maps.googleapis.com/maps/api/geocode/json';
+        return 'https://maps.googleapis.com/maps/api/geocode/json'
     }
 
     protected async buildQuery(query: GeocodeQuery): Promise<GoogleMapsGeocodeQueryInterface> {
@@ -44,6 +45,10 @@ export class GoogleMapsGeocodeCommand extends GoogleMapsLocationCommandMixin(Geo
 
         if (query.countryCode) {
             providerQuery.region = `.${query.countryCode.toLowerCase()}`;
+        }
+
+        if (this.secret) {
+            providerQuery.signature = urlSign('/maps/api/geocode/json', providerQuery, this.secret);
         }
 
         return providerQuery;

--- a/src/provider/google-maps/command/google-maps-reverse.command.ts
+++ b/src/provider/google-maps/command/google-maps-reverse.command.ts
@@ -3,14 +3,15 @@ import { ReverseCommand } from '../../../command';
 import type { ReverseQuery } from '../../../model';
 import type { GoogleMapsReverseQueryInterface } from '../interface';
 import { GoogleMapsLocationCommandMixin } from './mixin';
+import { urlSign } from '../../../util/url-signing';
 
 /**
  * TODO implement result_type and location_type
  * @link {https://developers.google.com/maps/documentation/geocoding/intro#ReverseGeocoding}
  */
 export class GoogleMapsReverseCommand extends GoogleMapsLocationCommandMixin(ReverseCommand)<GoogleMapsReverseQueryInterface> {
-    constructor(httpClient: AxiosInstance, private readonly apiKey: string) {
-        super(httpClient, apiKey);
+    constructor(httpClient: AxiosInstance, private readonly apiKey: string, private readonly secret?: string) {
+        super(httpClient, apiKey, secret);
     }
 
     static getUrl(): string {
@@ -28,6 +29,10 @@ export class GoogleMapsReverseCommand extends GoogleMapsLocationCommandMixin(Rev
 
         if (query.countryCode) {
             providerQuery.region = `.${query.countryCode.toLowerCase()}`;
+        }
+
+        if (this.secret) {
+            providerQuery.signature = urlSign('/maps/api/geocode/json', providerQuery, this.secret);
         }
 
         return providerQuery;

--- a/src/provider/google-maps/google-maps.provider.ts
+++ b/src/provider/google-maps/google-maps.provider.ts
@@ -9,10 +9,10 @@ import {
 } from './command';
 
 export class GoogleMapsProvider extends AbstractHttpProvider {
-    constructor(httpClient: AxiosInstance, apiKey: string) {
+    constructor(httpClient: AxiosInstance, apiKey: string, secret?: string) {
         super({
-            geocode: new GoogleMapsGeocodeCommand(httpClient, apiKey),
-            reverse: new GoogleMapsReverseCommand(httpClient, apiKey),
+            geocode: new GoogleMapsGeocodeCommand(httpClient, apiKey, secret),
+            reverse: new GoogleMapsReverseCommand(httpClient, apiKey, secret),
             suggest: new GoogleMapsSuggestCommand(httpClient, apiKey),
             placeDetails: new GoogleMapsPlaceDetailsCommand(httpClient, apiKey),
             distance: new GoogleMapsDistanceCommand(httpClient, apiKey),

--- a/src/provider/google-maps/interface/google-maps-query.interface.ts
+++ b/src/provider/google-maps/interface/google-maps-query.interface.ts
@@ -7,4 +7,9 @@ export interface GoogleMapsQueryInterface {
      */
     region?: string;
     language: string;
+    /**
+     * Signature for signed request to Google Maps API to bypass the 25k requests/day limit
+     * https://developers.google.com/maps/documentation/maps-static/digital-signature#server-side-signing
+     */
+    signature?: string;
 }

--- a/src/util/url-signing/index.ts
+++ b/src/util/url-signing/index.ts
@@ -1,0 +1,1 @@
+export * from './url-signing';

--- a/src/util/url-signing/url-signing.ts
+++ b/src/util/url-signing/url-signing.ts
@@ -1,0 +1,62 @@
+/**
+ * Example from https://googlemaps.github.io/url-signing/urlSigner.js
+ */
+import crypto from 'crypto';
+
+/**
+ * Convert from 'web safe' base64 to true base64.
+ *
+ * @param  {string} safeEncodedString The code you want to translate
+ *                                    from a web safe form.
+ * @return {string}
+ */
+function removeWebSafe(safeEncodedString: string): string {
+    return safeEncodedString.replace(/-/g, '+').replace(/_/g, '/');
+}
+
+/**
+ * Convert from true base64 to 'web safe' base64
+ *
+ * @param  {string} encodedString The code you want to translate to a
+ *                                web safe form.
+ * @return {string}
+ */
+function makeWebSafe(encodedString: string): string {
+    return encodedString.replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+/**
+ * Takes a base64 code and decodes it.
+ *
+ * @param  {string} code The encoded data.
+ * @return {Buffer}
+ */
+function decodeBase64Hash(code: string): Buffer {
+    // "new Buffer(...)" is deprecated. Use Buffer.from if it exists.
+    return Buffer.from ? Buffer.from(code, 'base64') : new Buffer(code, 'base64');
+}
+
+/**
+ * Takes a key and signs the data with it.
+ *
+ * @param  {string} key  Your unique secret key.
+ * @param  {string} data The url to sign.
+ * @return {string}
+ */
+function encodeBase64Hash(key: string, data: string): string {
+    return crypto.createHmac('sha1', key).update(data).digest('base64');
+}
+
+/**
+ * Sign a URL using a secret key.
+ *
+ * @param  {string} path   The url you want to sign.
+ * @param  {string} secret Your unique secret key.
+ * @param  {Object} query Query object
+ * @return {string}
+ */
+export function urlSign(path: string, query: any, secret: string, ): string {
+    const queryString = new URLSearchParams(JSON.stringify(query)).toString();
+    const safeSecret = decodeBase64Hash(removeWebSafe(secret)).toString('base64');
+    return makeWebSafe(encodeBase64Hash(safeSecret, path + queryString));
+}


### PR DESCRIPTION
ref #FSMWO-1806

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://github.com/goparrot/geocoder/blob/master/CONTRIBUTING.md#contributing
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->

<!-- This is a 🙋 feature or enhancement. -->

<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `npm test` to verify this)
-->

## Summary
This changes implement signing of requests to Google Maps API's, so that the limit of 25k request is not hit, by extending Google Maps provider to accept secret key and then using it to generate the signature parameter for requests.
<!--
  Provide a description of what your pull request changes.
-->

## Context

Creating unsigned request to Google Maps API will hit rate limit of 25k requests per day. This can be bypassed be singing request on the internal service side.

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
